### PR TITLE
Simplify SimpleOrbit

### DIFF
--- a/src/Transits.jl
+++ b/src/Transits.jl
@@ -80,9 +80,8 @@ julia> ld(orbit, 0u"d", 0.1)
 """
 function compute(ld::AbstractLimbDark, orbit::AbstractOrbit, t, r)
     coords = Orbits.relative_position(orbit, t)
-    z = sqrt(coords[1]^2 + coords[2]^2)
-    b = z / orbit.r_star
-    return compute(ld, b, r)
+    μ = sqrt(coords[1]^2 + coords[2]^2)
+    return compute(ld, μ, r)
 end
 
 include("elliptic.jl")

--- a/src/orbits/Orbits.jl
+++ b/src/orbits/Orbits.jl
@@ -1,6 +1,5 @@
 module Orbits
 
-using KeywordDispatch
 using StaticArrays
 
 export SimpleOrbit, KeplerianOrbit

--- a/src/orbits/Orbits.jl
+++ b/src/orbits/Orbits.jl
@@ -1,5 +1,6 @@
 module Orbits
 
+using KeywordDispatch
 using StaticArrays
 
 export SimpleOrbit, KeplerianOrbit
@@ -10,6 +11,8 @@ Base.broadcastable(o::AbstractOrbit) = Ref(o)
 
 """
     relative_position(::AbstractOrbit, t)
+
+The relative position, `[x, y, z]`, of the companion compared to the host at time `t`. In other words, this is the vector pointing from the host to the companion along the line of sight. Nominally, the units of this distance are relative to the host's radius. For example, a distance of 2 is 2 *stellar* radii.
 """
 relative_position(::AbstractOrbit, t)
 

--- a/src/orbits/simple.jl
+++ b/src/orbits/simple.jl
@@ -1,17 +1,15 @@
-struct SimpleOrbit{T,V} <: AbstractOrbit
+struct SimpleOrbit{T,V,S} <: AbstractOrbit
     period::T
     t0::T
     b::V
     duration::T
-    speed::V
+    speed::S
     half_period::T
     ref_time::T
 end
 
-# @kwdispatch SimpleOrbit(;P => period, T => duration, t₀ => t0, Rₛ => Rs)
-
 """
-    SimpleOrbit(; period, duration, t0=0, b=0, Rs=1)
+    SimpleOrbit(; period, duration, t0=0, b=0)
 
 Circular orbit parameterized by the basic observables of a transiting system.
 
@@ -20,9 +18,8 @@ Circular orbit parameterized by the basic observables of a transiting system.
 * `T`/`duration` - The duration of the transit, similar units as `period`.
 * `t₀`/`t0` - The midpoint time of the reference transit, similar units as `period`
 * `b` - The impact parameter of the orbit, unitless
-* `Rₛ`/`Rs` - The radius of the star, nominally in solar radii. This is only used in the case of [`SecondaryLimbDark`](@ref).
 """
-function SimpleOrbit(;period, duration, t0=zero(period), b=0.0)
+function SimpleOrbit(;period, duration, t0=zero(period), b=0)
     half_period = 0.5 * period
     duration > half_period && error("duration cannot be longer than half the period")
     speed = 2 * sqrt(1 - b^2) / duration
@@ -66,7 +63,6 @@ function Base.show(io::IO, orbit::SimpleOrbit)
     P = orbit.period
     b = orbit.b
     t0 = orbit.t0
-    Rs = orbit.Rs
     print(io, "SimpleOrbit(P=$P, T=$T, t0=$t0, b=$b)")
 end
 

--- a/src/secondary.jl
+++ b/src/secondary.jl
@@ -51,11 +51,11 @@ function SecondaryLimbDark(u1::AbstractVector, u2=u1; kwargs...)
     return SecondaryLimbDark(driver1, driver2; kwargs...)
 end
 
-function compute(ld::SecondaryLimbDark, orbit::AbstractOrbit, t, r; kwargs...)
-    f1 = ld.primary_driver(orbit, t, r; kwargs...)
-    orbit2 = Orbits.flip(orbit, r * orbit.r_star)
-    f2 = ld.secondary_driver(orbit2, t, 1/r; kwargs...)
-    flux_ratio = ld.brightness_ratio * r^2
+function compute(ld::SecondaryLimbDark, orbit::AbstractOrbit, t, ror; kwargs...)
+    f1 = ld.primary_driver(orbit, t, ror; kwargs...)
+    orbit2 = Orbits.flip(orbit, ror)
+    f2 = ld.secondary_driver(orbit2, t, inv(ror); kwargs...)
+    flux_ratio = ld.brightness_ratio * ror^2
     return (f1 + flux_ratio * f2) / (1 + flux_ratio)
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -55,13 +55,12 @@ end
 @testset "SimpleOrbit" begin
     orbit = SimpleOrbit(duration=1, period=3)
 
-    @test sprint(show, orbit) == "SimpleOrbit(P=3.0, T=1.0, t0=0.0, b=0.0, r_star=1.0)"
+    @test sprint(show, orbit) == "SimpleOrbit(P=3.0, T=1.0, t0=0.0, b=0)"
 
     @test sprint(show, "text/plain", orbit) == """
     SimpleOrbit
      period: 3.0
      duration: 1.0
      t0: 0.0
-     b: 0.0
-     r_star: 1.0"""
+     b: 0"""
 end


### PR DESCRIPTION
- update `SecondaryLimbDark` to use `ror` instead of `r_planet`
- relative_position returns distances in units of Rstar
- update SimpleOrbit to use relative distances, remove r_star
- update tests and fix breaks


This PR removes `r_star` from the `SimpleOrbit` struct, and rewrites related methods to be nominally in units of the stellar radius. This corresponds with the new Keplerian implementation #6. In addition, a few random methods defined for `SimpleOrbit` were removed to clean up.
