### PR TITLE
Revert "CompatHelper: bump compat for Bijectors to 0.13, (keep existing compat)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 
 [compat]
 AstroLib = "0.4"
-Bijectors = "0.8, 0.9, 0.10, 0.13"
+Bijectors = "0.8, 0.9, 0.10"
 ChainRulesCore = "1"
 ConcreteStructs = "0.2"
 Distributions = "0.22, 0.23, 0.24, 0.25"


### PR DESCRIPTION
Reverts JuliaAstro/Transits.jl#41