### PR TITLE
Update Bijectors.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ UnitfulAstro = "6112ee07-acf9-5e0f-b108-d242c714bf9f"
 
 [compat]
 AstroLib = "0.4"
-Bijectors = "0.8, 0.9, 0.10"
+Bijectors = "0.8, 0.9, 0.10, 0.11, 0.12, 0.13, 0.14, 0.15"
 ChainRulesCore = "1"
 ConcreteStructs = "0.2"
 Distributions = "0.22, 0.23, 0.24, 0.25"

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -47,7 +47,7 @@ end
 
 _logpdf(::Kipping13, x::AbstractArray{T}) where {T} = zero(T)
 
-struct Kipping13Transform <: Bijector{1} end
+struct Kipping13Transform <: Bijector end
 
 function (::Kipping13Transform)(x::AbstractVector)
     usum = sum(x)


### PR DESCRIPTION
Closes #39

Looks like `Bijector{N} --> Bijector` now since https://github.com/TuringLang/Bijectors.jl/pull/214

Relevant commit in [v0.10.8..v0.11.0 diff](https://github.com/TuringLang/Bijectors.jl/compare/v0.10.8...v0.11.0): https://github.com/TuringLang/Bijectors.jl/pull/214/commits/0717e3e7af25a0e63a791cf4f54674b36fe3cd4d